### PR TITLE
Add debugger toggling hotkey

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -506,6 +506,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   timeRemainingText: {fileID: 1043665535}
+  timeRemaining: 10
 --- !u!4 &576963517
 Transform:
   m_ObjectHideFlags: 0
@@ -695,6 +696,49 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 825571507}
   m_CullTransparentMesh: 0
+--- !u!1 &886806593
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 886806595}
+  - component: {fileID: 886806594}
+  m_Layer: 0
+  m_Name: Debugger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &886806594
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 886806593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26deef0aa6900424c9fdcde84ce5d0ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &886806595
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 886806593}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1090, y: 674, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BobaSpawner.cs
+++ b/Assets/Scripts/BobaSpawner.cs
@@ -13,7 +13,7 @@ public class BobaSpawner : MonoBehaviour {
 
         if (timeSinceLastBoba > interval) {
             GameObject boba = Instantiate(bobaPrefab);
-            float xPosition = GlobalVariables.isDebug ? transform.position.x : Random.Range(-10.0f, 10.0f);
+            float xPosition = Debugger.Instance.IsOn ? transform.position.x : Random.Range(-10.0f, 10.0f);
 
             boba.transform.position = new Vector3(
                 xPosition,

--- a/Assets/Scripts/Debugger.cs
+++ b/Assets/Scripts/Debugger.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public interface IDebuggerListener {
+    void DebuggerToggled();
+}
+
+public class Debugger : MonoBehaviour {
+    private static Debugger instance;
+    public static Debugger Instance {
+        get {
+            return instance;
+        }
+    }
+
+    private List<IDebuggerListener> listeners;
+    private bool isOn;
+    public bool IsOn {
+        get {
+            return isOn;
+        }
+
+        set {
+            isOn = value;
+
+            // Notify listeners
+            foreach (IDebuggerListener listener in listeners) {
+                listener.DebuggerToggled();
+            }
+        }
+    }
+
+    private void Awake() {
+        if (instance != null && instance != this) {
+            Destroy(gameObject);
+            return;
+        }
+
+        instance = this;
+        listeners = new List<IDebuggerListener>();
+    }
+
+    private void Update() {
+        if (Input.GetKeyDown(KeyCode.BackQuote)) {
+            IsOn = !IsOn;
+        }
+    }
+
+    public void AddListener(IDebuggerListener listener) {
+        listeners.Add(listener);
+    }
+}

--- a/Assets/Scripts/Debugger.cs.meta
+++ b/Assets/Scripts/Debugger.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 88a46dea84eae49149a3b40fca7a261c
+guid: 26deef0aa6900424c9fdcde84ce5d0ee
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/GameUI.cs
+++ b/Assets/Scripts/GameUI.cs
@@ -3,12 +3,21 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class GameUI : MonoBehaviour {
+public class GameUI : MonoBehaviour, IDebuggerListener {
     public Text bobaCount;
     public Text timeRemainingText;
 
     private void Start() {
-        bobaCount.gameObject.SetActive(GlobalVariables.isDebug);
-        timeRemainingText.gameObject.SetActive(GlobalVariables.isDebug);
+        Debugger.Instance.AddListener(this);
+        UpdateVisibilities();
+    }
+
+    public void DebuggerToggled() {
+        UpdateVisibilities();
+    }
+
+    private void UpdateVisibilities() {
+        bobaCount.gameObject.SetActive(Debugger.Instance.IsOn);
+        timeRemainingText.gameObject.SetActive(Debugger.Instance.IsOn);
     }
 }

--- a/Assets/Scripts/GlobalVariables.cs
+++ b/Assets/Scripts/GlobalVariables.cs
@@ -1,6 +1,0 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-
-public class GlobalVariables {
-    public static bool isDebug = false;
-}

--- a/Assets/Scripts/TitleMenu.cs
+++ b/Assets/Scripts/TitleMenu.cs
@@ -8,7 +8,7 @@ public class TitleMenu : MonoBehaviour {
     public Toggle debugToggle;
 
     private void Start() {
-        GlobalVariables.isDebug = debugToggle.isOn;
+        Debugger.Instance.IsOn = debugToggle.isOn;
     }
 
     public void StartGame() {
@@ -20,6 +20,6 @@ public class TitleMenu : MonoBehaviour {
     }
 
     public void SetDebug(bool isDebug) {
-        GlobalVariables.isDebug = isDebug;
+        Debugger.Instance.IsOn = isDebug;
     }
 }


### PR DESCRIPTION
This branch adds the backtick key as a hotkey for turning the debugger on and off.

In order to do this, we had to restructure the debugger checking code a little, since `GameUI` was only checking the debugger value in `Start()`. We replaced `GlobalVariables.isDebug` with a `Debugger` class (which is a singleton) that has an `IsOn` property. We also used the event listener design pattern to let other classes (like `GameUI`) listen for changes to `Debugger.Instance.IsOn`.

/cc @jessicard 