### PR TITLE
Allow phases to end early

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -615,6 +615,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4710beb4d37f549e6a495359bd8d8d98, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  phaseEnding: 0
+  bobaPlacer: {fileID: 8646206877487016826}
   bobaSpawner: {fileID: 286188011}
 --- !u!114 &576963519
 MonoBehaviour:
@@ -628,6 +630,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60e88215f58f34527b19260461a6fac9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  phaseEnding: 0
   liquidSpawner: {fileID: 1079247979}
 --- !u!1 &609153969
 GameObject:
@@ -2302,6 +2305,11 @@ PrefabInstance:
       propertyPath: bobaCountText
       value: 
       objectReference: {fileID: 1408072806}
+    - target: {fileID: 3354550414495793895, guid: 085f12f3e603343d283dff5825a08724,
+        type: 3}
+      propertyPath: bobaPhase
+      value: 
+      objectReference: {fileID: 576963518}
     - target: {fileID: 4372339344446634623, guid: 085f12f3e603343d283dff5825a08724,
         type: 3}
       propertyPath: m_Name
@@ -2314,3 +2322,15 @@ PrefabInstance:
       objectReference: {fileID: 1871739564}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 085f12f3e603343d283dff5825a08724, type: 3}
+--- !u!114 &8646206877487016826 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 701384633801086272, guid: 085f12f3e603343d283dff5825a08724,
+    type: 3}
+  m_PrefabInstance: {fileID: 8646206877487016825}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b69f766b950a412ab5e91832a33bee9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/Boba.cs
+++ b/Assets/Scripts/Boba.cs
@@ -29,6 +29,7 @@ public class Boba : MonoBehaviour {
 
     public void FallIntoCup(CupController cup) {
         BobaPlacer bobaPlacer = cup.GetComponentInChildren<BobaPlacer>();
+
         transform.parent = bobaPlacer.transform;
 
         manuallyFalling = true;

--- a/Assets/Scripts/BobaPlacer.cs
+++ b/Assets/Scripts/BobaPlacer.cs
@@ -7,20 +7,33 @@ public class BobaPlacer : MonoBehaviour {
 
     float bobaSize = 0.18f;
     int layerIndex = 0;
+    Vector3 defaultPosition;
 
     List<List<float>> bobaPositions = new List<List<float>> {
         new List<float> {  0.0f, 1.0f, 2.0f, 3.0f, 4.0f },
         new List<float> { -0.2f, 0.8f, 1.8f, 2.8f, 3.8f },
         new List<float> { -0.4f, 0.6f, 1.6f, 2.6f, 3.6f },
         new List<float> {  0.4f, 1.4f, 2.4f, 3.4f, 4.4f },
-    } ;
+    };
+
+    private void Awake() {
+        List<float> lastLayer = bobaPositions[bobaPositions.Count - 1];
+        defaultPosition = GeneratePosition(lastLayer[lastLayer.Count - 1], bobaPositions.Count - 1);
+    }
+
+    public bool HasPositions() {
+        return layerIndex < bobaPositions.Count;
+    }
 
     public Vector3 PopPosition() {
+        // If we run out of positions before the phase is over while boba is still falling,
+        // return a previous position to avoid errors.
+        if (!HasPositions()) {
+            return defaultPosition;
+        }
+
         int positionIndex = Random.Range(0, bobaPositions[layerIndex].Count);
-        float xPosition = bobaPositions[layerIndex][positionIndex] * bobaSize;
-        float yPosition = (float)layerIndex * bobaSize * 0.85f;
-        float zPosition = 0.0f;
-        Vector3 position = new Vector3(xPosition, yPosition, zPosition);
+        Vector3 position = GeneratePosition(bobaPositions[layerIndex][positionIndex], layerIndex);
 
         bobaPositions[layerIndex].RemoveAt(positionIndex);
 
@@ -29,5 +42,13 @@ public class BobaPlacer : MonoBehaviour {
         }
 
         return position;
+    }
+
+    private Vector3 GeneratePosition(float normalizedXPosition, int layerIndex) {
+        float xPosition = normalizedXPosition * bobaSize;
+        float yPosition = layerIndex * bobaSize * 0.85f;
+        float zPosition = 0.0f;
+
+        return new Vector3(xPosition, yPosition, zPosition);
     }
 }

--- a/Assets/Scripts/Catchers/BobaCatcher.cs
+++ b/Assets/Scripts/Catchers/BobaCatcher.cs
@@ -5,6 +5,8 @@ using UnityEngine.UI;
 
 public class BobaCatcher : MonoBehaviour {
     public Text bobaCountText;
+    public BobaPhase bobaPhase;
+
     private int bobaCount = 0;
     private int BobaCount {
         get {
@@ -23,6 +25,10 @@ public class BobaCatcher : MonoBehaviour {
         if (boba != null) {
             boba.FallIntoCup(GetComponentInParent<CupController>());
             BobaCount++;
+
+            if (bobaPhase.ShouldEndEarly()) {
+                bobaPhase.EndPhaseEarly();
+            }
         }
     }
 }

--- a/Assets/Scripts/GamePhases/BobaPhase.cs
+++ b/Assets/Scripts/GamePhases/BobaPhase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class BobaPhase : GamePhase {
+    public BobaPlacer bobaPlacer;
     public BobaSpawner bobaSpawner;
 
     public override float EndDelay {
@@ -31,5 +32,9 @@ public class BobaPhase : GamePhase {
 
     protected override void StartNextPhase() {
         GetComponent<LiquidPhase>().StartPhase();
+    }
+
+    public override bool ShouldEndEarly() {
+        return !bobaPlacer.HasPositions();
     }
 }

--- a/Assets/Scripts/GamePhases/GamePhase.cs
+++ b/Assets/Scripts/GamePhases/GamePhase.cs
@@ -40,6 +40,10 @@ public abstract class GamePhase : MonoBehaviour {
         }));
     }
 
+    public void EndPhaseEarly() {
+        phaseManager.SkipPhase();
+    }
+
     private IEnumerator DelayPhase(float delay, System.Action callback) {
         yield return new WaitForSeconds(delay);
         callback();
@@ -48,4 +52,6 @@ public abstract class GamePhase : MonoBehaviour {
     protected abstract void ExecuteStart();
     protected abstract void ExecuteEnd();
     protected abstract void StartNextPhase();
+
+    public abstract bool ShouldEndEarly();
 }

--- a/Assets/Scripts/GamePhases/LiquidPhase.cs
+++ b/Assets/Scripts/GamePhases/LiquidPhase.cs
@@ -27,4 +27,8 @@ public class LiquidPhase : GamePhase {
     protected override void StartNextPhase() {
         Debug.Log("NO NEXT PHASE");
     }
+
+    public override bool ShouldEndEarly() {
+        return false;
+    }
 }

--- a/Assets/Scripts/PhaseManager.cs
+++ b/Assets/Scripts/PhaseManager.cs
@@ -63,7 +63,9 @@ public class PhaseManager : MonoBehaviour {
     }
 
     public void SkipPhase() {
-        TimeRemaining = currentPhase.EndDelay;
+        if (!currentPhase.phaseEnding) {
+            TimeRemaining = currentPhase.EndDelay;
+        }
     }
 
     private bool IsInStartDelay() {


### PR DESCRIPTION
This branch makes it so phases can be ended early if certain conditions are met. `LiquidPhase` currently has no way to end early, but `BobaPhase` can be ended early if all the positions in `BobaPlacer` are filled.

Adding this behavior required us to also handle what happens when boba fall into a cup with all positions filled. When this happens, we now place the boba in the last-filled position, so that it doesn't look too strange visually.

/cc @jessicard 