### PR TITLE
Fix boba getting knocked around by liquid fill clipping plane

### DIFF
--- a/Assets/Prefabs/Cup Variant.prefab
+++ b/Assets/Prefabs/Cup Variant.prefab
@@ -75,6 +75,18 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &8774943833106552423
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1780602450587893468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 06d29d48c27ee4d44afae7e628b01d1f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2014477892598289802
 GameObject:
   m_ObjectHideFlags: 0
@@ -177,7 +189,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2300675392757964588}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 0.1, z: 1}
@@ -534,18 +546,6 @@ LineRenderer:
     generateLightingData: 0
   m_UseWorldSpace: 0
   m_Loop: 0
---- !u!114 &8774943833106552423
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1780602450587893468}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 06d29d48c27ee4d44afae7e628b01d1f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &2694455254242775540
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
In #47, I added a collider to the liquid fill clipping plane, which introduced a bug where it would sometimes knock boba around and cause them to stop moving or get knocked to a side.

This branch fixes the bug by marking the collider as a trigger, so it detects collisions but doesn't impact physics.

/cc @jessicard 