### PR TITLE
Make liquid colors look better on grading screen

### DIFF
--- a/Assets/Scenes/GradeScene.unity
+++ b/Assets/Scenes/GradeScene.unity
@@ -20,13 +20,13 @@ RenderSettings:
   m_FogDensity: 0.01
   m_LinearFogStart: 0
   m_LinearFogEnd: 300
-  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientSkyColor: {r: 0.7490196, g: 0.7490196, b: 0.7490196, a: 1}
   m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
-  m_AmbientMode: 0
+  m_AmbientMode: 3
   m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
-  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_SkyboxMaterial: {fileID: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
   m_FlareFadeSpeed: 3

--- a/Assets/Scripts/CupContainer.cs
+++ b/Assets/Scripts/CupContainer.cs
@@ -12,6 +12,14 @@ public class CupContainer : MonoBehaviour {
     }
 
     public void PrepareForGradeScreen() {
+        Renderer cupRenderer = cup.GetComponent<Renderer>();
+        Color cupColor = cupRenderer.material.color;
+        cupRenderer.material.color = new Color(
+            cupColor.r,
+            cupColor.g,
+            cupColor.b,
+            0.5f
+        );
         cup.transform.localPosition = Vector3.zero;
         Destroy(arm);
 


### PR DESCRIPTION
This branch makes the liquid colors look better on the grading screen, by doing these two things:

* Using the same ambient lighting values that are used in the main scene.
* Setting 50% opacity on the cup model so the liquid can be seen more clearly.

/cc @jessicard 