### PR TITLE
Fix phantom arm on title screen

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -3974,6 +3974,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e4eba1feca58749c7b2649fce232409c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cupContainer: {fileID: 1843330135}
   menuContainer: {fileID: 281675207}
 --- !u!1 &1165758031
 GameObject:

--- a/Assets/Scripts/PauseMenu.cs
+++ b/Assets/Scripts/PauseMenu.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 
 public class PauseMenu : MonoBehaviour {
+    public CupContainer cupContainer;
     public GameObject menuContainer;
 
     private float oldTimeScale;
@@ -39,6 +40,13 @@ public class PauseMenu : MonoBehaviour {
     }
 
     public void ExitGame() {
+        // HACK: CupContainer calls DontDestroyOnLoad, so we need to manually
+        // destroy it if we exit via the pause menu. There's definitely multiple
+        // better ways to do this, which we should investigate in the future.
+        if (cupContainer) {
+            Destroy(cupContainer.gameObject);
+        }
+
         GameManager.StartTitleScene();
     }
 }

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -38,6 +38,7 @@ GraphicsSettings:
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16002, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
Currently, if you're playing the game and you exit via the pause menu, the title screen ends up with a phantom arm floating around on it. This branch fixes it. The problem is detailed in the `HACK` comment in `PauseMenu.cs`.

/cc @jessicard 